### PR TITLE
Don't require partialsDir

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -80,12 +80,12 @@ function cachePartials() {
  * @param {Object} options - { handlebars: "override handlebars", partialsDir: "absolute path to partials", extname: "extension to use" }
  */
 exports.express3 = function(options) {
-  if (options.handlebars) exports.handlebars = options.handlebars;
+  if (options && options.handlebars) exports.handlebars = options.handlebars;
 
   exports.handlebars.registerHelper('contentFor', contentFor);
   exports.handlebars.registerHelper('block', block);
 
-  partialsDir = options.partialsDir;
+  partialsDir = options && options.partialsDir;
   if (partialsDir) cachePartials();
 
   return _express3;
@@ -102,7 +102,7 @@ var _express3 = function(filename, options, cb) {
 
   // Force reloading of all partials if cachine not used. Inefficient but there
   // is no loading partial event.
-  if (!options.cache) cachePartials();
+  if (!options.cache && partialsDir) cachePartials();
 
   /**
    * Allow a layout to be declared as a handlebars comment to remain spec compatible


### PR DESCRIPTION
Don't call cachePartials() if partialsDir has not been set.

This patch also makes options optional.
