### PR TITLE
- Update cachePartials() to skip over non-files.

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -110,7 +110,11 @@ function cachePartials() {
     var files = fs.readdirSync(partialsDir);
 
     files.forEach(function(file) {
-        var source = fs.readFileSync(path.join(partialsDir, file), 'utf8');
+        var filePath = path.join(partialsDir, file);
+        var stats = fs.statSync(filePath);
+        if (!stats.isFile()) return;
+
+        var source = fs.readFileSync(filePath, 'utf8');
         var name = path.basename(file, path.extname(file));
         exports.handlebars.registerPartial(name, source);
     });


### PR DESCRIPTION
Running express-hbs 0.1.2-pre, we encountered that `cachePartials()` was reading directories under `<view>/partials` and throwing an error.  (In our case, our partials directory was actually empty except for the .svn dir created by subversion.)  So here's a patch to call `fs.statSync()` on each file and only load them if they are actually files.
