### PR TITLE
Suppressing default layout from a render call

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To define block content in a page.
       CONTENT HERE
     {{/contentFor}}
 
-There are three ways to use a layout
+There are three ways to use a layout, listed in the order in which they are checked for and used:
 
 1. Declarative within a page. Use handlebars comment. `LAYOUT` is a relative path from template.
 
@@ -60,6 +60,16 @@ There are three ways to use a layout
       veggies: veggies,
       layout: 'layout/veggie'
     });
+    
+   This option also allows for default layout suppression by passing in a falsey Javascript value as the value of the `layout` property:
+
+```   
+    res.render('veggies', {
+      title: 'My favorite veggies',
+      veggies: veggies,
+      layout: null // render without using a layout template
+    });
+```
 
 3. Lastly, use `defaultLayout` if specified in hbs configuration options.
 

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -272,12 +272,18 @@ var _express3 = function(filename, options, cb) {
         }
 
         //   2. Layout specified by options from render
-        else if (options.layout) {
-          var layoutFile = path.resolve(path.join(path.dirname(filename), options.layout));
-          cacheLayout(layoutFile, options.cache, function(err, layoutTemplate) {
-            if (err) return cb(err);
-            renderIt(layoutTemplate);
-          });
+        else if (typeof(options.layout) !== 'undefined') {
+          if (options.layout) {
+            var layoutFile = path.resolve(path.join(path.dirname(filename), options.layout));
+            cacheLayout(layoutFile, options.cache, function(err, layoutTemplate) {
+              if (err) return cb(err);
+              renderIt(layoutTemplate);
+            });
+            
+          } else {
+            // if the value is falsey, behave as if no layout should be used - suppress defaults
+            renderIt(null);
+          }
         }
 
         //   3. Default layout specified when middleware was configured.


### PR DESCRIPTION
I've added support to suppress the default layout from the invocation of the render function on Express' response object. This is accomplished by passing a falsey (null, false, '') value as the value of the 'layout' property.

This is a feature supported by donpark/hbs module that I really missed in your own implementation.
