### PR TITLE
Adding template option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Options for `#express3`
       defaultLayout: "{String} Absolute path to default layout template",
       extname: "{String} Extension for templates, defaults to `.hbs`",
       handlebars: "{Module} Use external handlebars instead of express-hbs dependency",
-      layoutsDir: "{String} Path to layout templates"
+      layoutsDir: "{String} Path to layout templates",
+      templateOptions: "{Object} options to pass to template()"
     });
 
 Partials may use any extension, which is better for syntax highlighting.

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -151,6 +151,7 @@ exports.express3 = function (options) {
   if (!_options.extname) _options.extname = '.hbs';
   if (!_options.contentHelperName) _options.contentHelperName = 'contentFor';
   if (!_options.blockHelperName) _options.blockHelperName = 'block';
+  if (!_options.templateOptions) _options.templateOptions = {};
   if (_options.handlebars) exports.handlebars = _options.handlebars;
 
   exports.handlebars.registerHelper(_options.blockHelperName, block);
@@ -227,7 +228,7 @@ var _express3 = function (filename, options, cb) {
    * Renders `template` with an optional `layoutTemplate` using data in `locals`.
    */
   function render(template, locals, layoutTemplate, cb) {
-    var res = template(locals);
+    var res = template(locals, _options.templateOptions);
     async.done(function (values) {
       Object.keys(values).forEach(function (id) {
         res = res.replace(id, values[id]);


### PR DESCRIPTION
As per http://handlebarsjs.com/execution.html#Options handlebars supports passing an options object to template().
This change allows this to be specified along with the hbs.express3 options
Updated README with new option
