### PR TITLE
Switch from glob to readdirp

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var glob = require('glob');
+var readdirp = require('readdirp');
 exports.handlebars = require('handlebars');
 
 /**
@@ -115,20 +115,27 @@ function cacheLayout(layoutFile, useCache, cb) {
  *
  * @param {String} base The views directory.
  */
-function cachePartials() {
-  var files = glob.sync(partialsDir+'/**/*');
-  files.forEach(function (file) {
-    var stats = fs.statSync(file);
-    if (!stats.isFile()) return;
-    var source = fs.readFileSync(file, 'utf8');
-    // partials names are relative to partialsDir
-    var filepath = file.slice(partialsDir.length + 1);
-    var dirname = path.dirname(filepath);
-    dirname = dirname === '.' ? '' : dirname+'/';
+function cachePartials(cb) {
+  readdirp({ root: partialsDir, fileFilter: '*.*' })
+    .on('warn', function (err) {
+      console.warn('Non-fatal error in express-hbs cachePartials.', err);
+    })
+    .on('error', function (err) {
+      console.error('Fatal error in express-hbs cachePartials', err);
+      return cb(err);
+    })
+    .on('data', function (entry) {
+      if (!entry) return;
+      var source = fs.readFileSync(entry.fullPath, 'utf8');
+      var dirname = path.dirname(entry.path);
+      dirname = dirname === '.' ? '' : dirname + '/';
 
-    var name = dirname + path.basename(file, path.extname(file));
-    exports.handlebars.registerPartial(name, source);
-  });
+      var name = dirname + path.basename(entry.name, path.extname(entry.name));
+      exports.handlebars.registerPartial(name, source);
+    })
+    .on('end', function () {
+        cb && cb(null, true);
+    });
 }
 
 
@@ -158,7 +165,6 @@ exports.express3 = function (options) {
   exports.handlebars.registerHelper(_options.contentHelperName, content);
 
   partialsDir = _options.partialsDir;
-  if (partialsDir) cachePartials();
 
   layoutsDir = _options.layoutsDir;
 
@@ -192,10 +198,6 @@ var _express3 = function (filename, options, cb) {
   var handlebars = exports.handlebars;
 
   //console.log('options', options);
-
-  // Force reloading of all partials if cachine not used. Inefficient but there
-  // is no loading partial event.
-  if (!options.cache && partialsDir) cachePartials();
 
   // Unfortunately, express3 above is not async so check here to load the
   // default template once.
@@ -321,7 +323,21 @@ var _express3 = function (filename, options, cb) {
   // kick it off by loading default template (if any)
   loadDefaultLayout(options.cache, function (err) {
     if (err) return cb(err);
-    return compileFile(options, cb);
+
+    // Force reloading of all partials if cachine not used. Inefficient but there
+    // is no loading partial event.
+    if (!options.cache && partialsDir) {
+      cachePartials(function (err) {
+        if (err) {
+          return cb(err);
+        }
+
+        return compileFile(options, cb);
+      });
+    }
+    else {
+      return compileFile(options, cb);
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "handlebars": "~1.0.10",
-    "glob": "~3.1.21"
+    "readdirp": "~0.3.1"
   }
 }


### PR DESCRIPTION
Resolves an issue with `glob`/`minimatch` where UNC paths are not
interpreted correctly. Using `readdirp` instead allows us to use a more
robust, simplified and asynchronous approach to loading the partials.
