### PR TITLE
Fixed issue with partials not loading

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,26 @@
+module.exports = function configureGrunt(grunt) {
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+
+        mochacli: {
+            options: {
+                ui: 'bdd',
+                reporter: 'spec'
+            },
+
+            all: {
+                src: ['test/*.js']
+            }
+        }
+    });
+
+    grunt.registerTask('setProductionEnv', function () {
+        // Use 'production' config
+        process.env.NODE_ENV = 'production';
+    });
+
+    grunt.loadNpmTasks('grunt-mocha-cli');
+
+    // Run tests
+    grunt.registerTask('default', ['mochacli:all', 'setProductionEnv', 'mochacli:all']);
+};

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -47,6 +47,11 @@ var defaultLayoutTemplate;
  */
 var layoutPattern = /{{!<\s+([A-Za-z0-9\._\-\/]+)\s*}}/;
 
+/**
+ * Keep track of if partials have been cached already or not.
+ */
+var isPartialCachingComplete = false;
+
 
 /**
  * Defines a block into which content is inserted via `content`.
@@ -134,6 +139,7 @@ function cachePartials(cb) {
       exports.handlebars.registerPartial(name, source);
     })
     .on('end', function () {
+        isPartialCachingComplete = true;
         cb && cb(null, true);
     });
 }
@@ -324,10 +330,10 @@ var _express3 = function (filename, options, cb) {
   loadDefaultLayout(options.cache, function (err) {
     if (err) return cb(err);
 
-    // Force reloading of all partials if cachine not used. Inefficient but there
+    // Force reloading of all partials if caching is not used. Inefficient but there
     // is no loading partial event.
-    if (!options.cache && partialsDir) {
-      cachePartials(function (err) {
+    if (partialsDir && (!options.cache || !isPartialCachingComplete)) {
+      return cachePartials(function (err) {
         if (err) {
           return cb(err);
         }
@@ -335,9 +341,8 @@ var _express3 = function (filename, options, cb) {
         return compileFile(options, cb);
       });
     }
-    else {
-      return compileFile(options, cb);
-    }
+
+    return compileFile(options, cb);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "example": "example"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "grunt"
   },
   "repository": "https://github.com/barc/express-hbs",
   "author": "Mario Gutierrez (mario@barc.com)",
@@ -16,7 +16,9 @@
   "devDependencies": {
     "express": "~3.0.6",
     "supertest": "~0.5.1",
-    "mocha": "~1.9.0"
+    "mocha": "~1.9.0",
+    "grunt": "~0.4.1",
+    "grunt-mocha-cli": "~1.0.6"
   },
   "dependencies": {
     "handlebars": "~1.0.10",


### PR DESCRIPTION
Resolves an issue where partials are not loaded correctly in the event
the `options.cache` is set to `true`. Accordingly allows partials to be
loaded once, or loaded every time if caching is disabled.

In order to test both situations where caching may be on or off, we
toggle the `process.env.NODE_ENV` variable which in effect toggles the
`options.cache` parameter. Thus I have included grunt to run the same
test suite twice; once as the test suite was run before, and then again
with the environment variable set to production.
