### PR TITLE
Fix "this" context in async helpers

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -371,7 +371,7 @@ exports.registerPartial = function () {
 
 exports.registerAsyncHelper = function (name, fn) {
   exports.handlebars.registerHelper(name, function (context) {
-    return async.resolve(fn, context);
+    return async.resolve(fn.bind(this), context);
   });
 };
 


### PR DESCRIPTION
- Used .bind() to ensure the same this context for async helpers

We were running into a problem (TryGhost/Ghost#1357) since switching over to async helpers where the `this` context was not the same as regular helpers.  This change appears to remedy it, at least with my limited testing.
