### PR TITLE
Adds the possibility to create different instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ Asynchronous helpers
     # in markup
     {{{readFile 'tos.txt'}}}
 
+## Methods
+
+### Create multiple instance
+
+    var hbs = require('express-hbs');
+
+    var instance1 = hbs.create();
+    var instance2 = hbs.create();
+
+    This allows you to create isolated instances with their own cache system and handlebars engine.
+
 ## Example
 
 in File `app.js`

--- a/example/app-layoutsDir.js
+++ b/example/app-layoutsDir.js
@@ -3,6 +3,9 @@
 var express = require('express');
 var app = express();
 var hbs = require('..'); // should be `require('express-hbs')` outside of this example
+var fs = require('fs');
+var path = require('path');
+var viewsDir = __dirname + '/views';
 
 app.use(express.static(__dirname + '/public'));
 
@@ -14,6 +17,25 @@ app.engine('hbs', hbs.express3({
 }));
 app.set('view engine', 'hbs');
 app.set('views', __dirname + '/views');
+
+
+// Register sync helper
+hbs.registerHelper('link', function(text, options) {
+  var attrs = [];
+  for (var prop in options.hash) {
+    attrs.push(prop + '="' + options.hash[prop] + '"');
+  }
+  return new hbs.SafeString(
+    "<a " + attrs.join(" ") + ">" + text + "</a>"
+  );
+});
+
+// Register Async helpers
+hbs.registerAsyncHelper('readFile', function(filename, cb) {
+  fs.readFile(path.join(viewsDir, filename), 'utf8', function(err, content) {
+    cb(new hbs.SafeString(content));
+  });
+});
 
 var fruits = [
   {name: 'apple'},

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -2,44 +2,12 @@
 var fs = require('fs');
 var path = require('path');
 var readdirp = require('readdirp');
-exports.handlebars = require('handlebars');
+var handlebars = require('handlebars');
 
 /**
  * Handle async helpers
  */
 var async = require('./async');
-
-/**
- * Cache for templates, express 3.x doesn't do this for us
- */
-var cache = {};
-
-/**
- * Blocks for layouts. Is this safe? What happens if the same block is used on multiple connections?
- * Isn't there a chance block and content  are not in sync. The template and layout are processed
- * asynchronously.
- */
-var blocks = {};
-
-/**
- * Absolute path to partials directory.
- */
-var partialsDir;
-
-/**
- * Absolute path to the layouts directory
- */
-var layoutsDir;
-
-/**
- * Keep copy of options configuration.
- */
-var _options;
-
-/**
- * Holds the default compiled layout if specified in options configuration.
- */
-var defaultLayoutTemplate;
 
 
 /**
@@ -47,10 +15,17 @@ var defaultLayoutTemplate;
  */
 var layoutPattern = /{{!<\s+([A-Za-z0-9\._\-\/]+)\s*}}/;
 
+
 /**
- * Keep track of if partials have been cached already or not.
+ * Constructor
  */
-var isPartialCachingComplete = false;
+var Instance = function(){
+  this.handlebars = handlebars.create();
+
+  // DEPRECATED, kept for backwards compatibility
+  this.SafeString = this.handlebars.SafeString;
+  this.Utils = this.handlebars.Utils;
+};
 
 
 /**
@@ -61,10 +36,10 @@ var isPartialCachingComplete = false;
  *
  *  {{{block "pageStylesheets"}}}
  */
-function block(name) {
-  var val = (blocks[name] || []).join('\n');
+function block(instance, name) {
+  var val = (instance.blocks[name] || []).join('\n');
   // clear the block
-  blocks[name] = [];
+  instance.blocks[name] = [];
   return val;
 }
 
@@ -78,10 +53,10 @@ function block(name) {
  * <link rel="stylesheet" href='{{{URL "css/style.css"}}}' />
  * {{/content}}
  */
-function content(name, context) {
-  var block = blocks[name];
+function content(instance, name, context) {
+  var block = instance.blocks[name];
   if (!block) {
-    block = blocks[name] = [];
+    block = instance.blocks[name] = [];
   }
   block.push(context.fn(this));
 }
@@ -91,28 +66,30 @@ function content(name, context) {
  *
  * @param {String} layoutFile
  */
-function cacheLayout(layoutFile, useCache, cb) {
+Instance.prototype.cacheLayout = function (layoutFile, useCache, cb) {
+
+  var self = this;
 
   // assume hbs extension
-  if (path.extname(layoutFile) === '') layoutFile += _options.extname;
+  if (path.extname(layoutFile) === '') layoutFile += this._options.extname;
 
   // path is relative in directive, make it absolute
-  var layoutTemplate = cache[layoutFile] ? cache[layoutFile].layoutTemplate : null;
+  var layoutTemplate = this.cache[layoutFile] ? this.cache[layoutFile].layoutTemplate : null;
   if (layoutTemplate) return cb(null, layoutTemplate);
 
   fs.readFile(layoutFile, 'utf8', function (err, str) {
     if (err) return cb(err);
 
-    layoutTemplate = exports.handlebars.compile(str);
+    layoutTemplate = self.handlebars.compile(str);
     if (useCache) {
-      cache[layoutFile] = {
+      self.cache[layoutFile] = {
         layoutTemplate: layoutTemplate
       };
     }
 
     cb(null, layoutTemplate);
   });
-}
+};
 
 
 /**
@@ -120,8 +97,10 @@ function cacheLayout(layoutFile, useCache, cb) {
  *
  * @param {String} base The views directory.
  */
-function cachePartials(cb) {
-  readdirp({ root: partialsDir, fileFilter: '*.*' })
+Instance.prototype.cachePartials = function (cb) {
+  var self = this; 
+
+  readdirp({ root: this.partialsDir, fileFilter: '*.*' })
     .on('warn', function (err) {
       console.warn('Non-fatal error in express-hbs cachePartials.', err);
     })
@@ -136,13 +115,13 @@ function cachePartials(cb) {
       dirname = dirname === '.' ? '' : dirname + '/';
 
       var name = dirname + path.basename(entry.name, path.extname(entry.name));
-      exports.handlebars.registerPartial(name, source);
+      self.handlebars.registerPartial(name, source);
     })
     .on('end', function () {
-        isPartialCachingComplete = true;
+        self.isPartialCachingComplete = true;
         cb && cb(null, true);
     });
-}
+};
 
 
 /**
@@ -159,22 +138,41 @@ function cachePartials(cb) {
  * }
  *
  */
-exports.express3 = function (options) {
-  _options = options || {};
-  if (!_options.extname) _options.extname = '.hbs';
-  if (!_options.contentHelperName) _options.contentHelperName = 'contentFor';
-  if (!_options.blockHelperName) _options.blockHelperName = 'block';
-  if (!_options.templateOptions) _options.templateOptions = {};
-  if (_options.handlebars) exports.handlebars = _options.handlebars;
+Instance.prototype.express3 = function (options) {
+  var self = this;
 
-  exports.handlebars.registerHelper(_options.blockHelperName, block);
-  exports.handlebars.registerHelper(_options.contentHelperName, content);
+  // Keep copy of options configuration.
+  this._options = options || {};
+  if (!this._options.extname) this._options.extname = '.hbs';
+  if (!this._options.contentHelperName) this._options.contentHelperName = 'contentFor';
+  if (!this._options.blockHelperName) this._options.blockHelperName = 'block';
+  if (!this._options.templateOptions) this._options.templateOptions = {};
+  if (this._options.handlebars) this.handlebars = this._options.handlebars;
 
-  partialsDir = _options.partialsDir;
+  // Keep the context call for the helpers and give the instance of express-hbs for access to blocks variables
+  this.handlebars.registerHelper(this._options.blockHelperName, function(name){ return block(self, name); });
+  this.handlebars.registerHelper(this._options.contentHelperName, function(name, context){ return content(self, name, context); });
+  
+  // Absolute path to partials directory.
+  this.partialsDir = this._options.partialsDir;
 
-  layoutsDir = _options.layoutsDir;
+  // Absolute path to the layouts directory
+  this.layoutsDir = this._options.layoutsDir;
 
-  return _express3;
+  // Cache for templates, express 3.x doesn't do this for us
+  this.cache = {};
+
+  // Blocks for layouts. Is this safe? What happens if the same block is used on multiple connections?
+  // Isn't there a chance block and content  are not in sync. The template and layout are processed asynchronously.
+  this.blocks = {};
+
+  // Holds the default compiled layout if specified in options configuration.
+  this.defaultLayoutTemplate = null;;
+
+  // Keep track of if partials have been cached already or not.
+  this.isPartialCachingComplete = false;
+
+  return _express3.bind(this);
 };
 
 
@@ -183,27 +181,27 @@ exports.express3 = function (options) {
  *
  * @param {Boolean} useCache Whether to cache.
  */
-function loadDefaultLayout(useCache, cb) {
-  if (!_options.defaultLayout) return cb();
-  if (useCache && defaultLayoutTemplate) return cb(null, defaultLayoutTemplate);
+Instance.prototype.loadDefaultLayout = function (useCache, cb) {
+  var self = this;
 
-  cacheLayout(_options.defaultLayout, useCache, function (err, template) {
+  if (!this._options.defaultLayout) return cb();
+  if (useCache && this.defaultLayoutTemplate) return cb(null, this.defaultLayoutTemplate);
+
+  this.cacheLayout(this._options.defaultLayout, useCache, function (err, template) {
     if (err) return cb(err);
 
-    defaultLayoutTemplate = template;
+    self.defaultLayoutTemplate = template;
     return cb(null, template);
   });
-}
-
+};
 
 
 /**
  * express 3.x template engine compliance
  */
 var _express3 = function (filename, options, cb) {
-  var handlebars = exports.handlebars;
-
-  //console.log('options', options);
+  
+  var self = this;
 
   // Unfortunately, express3 above is not async so check here to load the
   // default template once.
@@ -225,7 +223,7 @@ var _express3 = function (filename, options, cb) {
 
       // cacheLayout expects absolute path
       layout = layoutPath(filename, layout);
-      cacheLayout(layout, options.cache, cb);
+      self.cacheLayout(layout, options.cache, cb);
     } else {
       cb(null, null);
     }
@@ -238,7 +236,7 @@ var _express3 = function (filename, options, cb) {
    */
   function layoutPath(filename, layout) {
     var layoutWithDir = layout.split('/').length > 1;
-    var layoutsDirUsed = layoutWithDir ? null : layoutsDir;
+    var layoutsDirUsed = layoutWithDir ? null : self.layoutsDir;
     return path.resolve(path.join(layoutsDirUsed ? layoutsDirUsed : path.dirname(filename), layout));
   }
 
@@ -246,7 +244,7 @@ var _express3 = function (filename, options, cb) {
    * Renders `template` with an optional `layoutTemplate` using data in `locals`.
    */
   function render(template, locals, layoutTemplate, cb) {
-    var res = template(locals, _options.templateOptions);
+    var res = template(locals, self._options.templateOptions);
     async.done(function (values) {
       Object.keys(values).forEach(function (id) {
         res = res.replace(id, values[id]);
@@ -257,7 +255,7 @@ var _express3 = function (filename, options, cb) {
       // layout declare a {{{body}}} placeholder into which a page is inserted
       locals.body = res;
 
-      var layoutResult = layoutTemplate(locals, _options.templateOptions);
+      var layoutResult = layoutTemplate(locals, self._options.templateOptions);
       async.done(function (values) {
         Object.keys(values).forEach(function (id) {
           layoutResult = layoutResult.replace(id, values[id]);
@@ -276,7 +274,7 @@ var _express3 = function (filename, options, cb) {
     var cached, template, layoutTemplate;
 
     // check cache
-    cached = cache[filename];
+    cached = self.cache[filename];
     if (cached) {
       template = cached.template;
       layoutTemplate = cached.layoutTemplate;
@@ -286,9 +284,9 @@ var _express3 = function (filename, options, cb) {
     fs.readFile(filename, 'utf8', function (err, str) {
       if (err) return cb(err);
 
-      var template = handlebars.compile(str);
+      var template = self.handlebars.compile(str);
       if (options.cache) {
-        cache[filename] = {
+        self.cache[filename] = {
           template: template
         };
       }
@@ -299,7 +297,7 @@ var _express3 = function (filename, options, cb) {
 
         function renderIt(layoutTemplate) {
           if (layoutTemplate && options.cache) {
-            cache[filename].layoutTemplate = layoutTemplate;
+            self.cache[filename].layoutTemplate = layoutTemplate;
           }
           return render(template, locals, layoutTemplate, cb);
         }
@@ -314,7 +312,7 @@ var _express3 = function (filename, options, cb) {
         else if (typeof (options.layout) !== 'undefined') {
           if (options.layout) {
             var layoutFile = layoutPath(filename, options.layout);
-            cacheLayout(layoutFile, options.cache, function (err, layoutTemplate) {
+            self.cacheLayout(layoutFile, options.cache, function (err, layoutTemplate) {
               if (err) return cb(err);
               renderIt(layoutTemplate);
             });
@@ -326,8 +324,8 @@ var _express3 = function (filename, options, cb) {
         }
 
         //   3. Default layout specified when middleware was configured.
-        else if (defaultLayoutTemplate) {
-          renderIt(defaultLayoutTemplate);
+        else if (self.defaultLayoutTemplate) {
+          renderIt(self.defaultLayoutTemplate);
         }
 
         // render without a template
@@ -337,13 +335,13 @@ var _express3 = function (filename, options, cb) {
   }
 
   // kick it off by loading default template (if any)
-  loadDefaultLayout(options.cache, function (err) {
+  this.loadDefaultLayout(options.cache, function (err) {
     if (err) return cb(err);
 
     // Force reloading of all partials if caching is not used. Inefficient but there
     // is no loading partial event.
-    if (partialsDir && (!options.cache || !isPartialCachingComplete)) {
-      return cachePartials(function (err) {
+    if (self.partialsDir && (!options.cache || !self.isPartialCachingComplete)) {
+      return self.cachePartials(function (err) {
         if (err) {
           return cb(err);
         }
@@ -361,20 +359,21 @@ var _express3 = function (filename, options, cb) {
  * Expose useful methods.
  */
 
-exports.registerHelper = function () {
-  exports.handlebars.registerHelper.apply(exports.handlebars, arguments);
+Instance.prototype.registerHelper = function () {
+  this.handlebars.registerHelper.apply(this.handlebars, arguments);
 };
 
-exports.registerPartial = function () {
-  exports.handlebars.registerPartial.apply(exports.handlebars, arguments);
+Instance.prototype.registerPartial = function () {
+  this.handlebars.registerPartial.apply(this.handlebars, arguments);
 };
 
-exports.registerAsyncHelper = function (name, fn) {
-  exports.handlebars.registerHelper(name, function (context) {
+Instance.prototype.registerAsyncHelper = function (name, fn) {
+  this.handlebars.registerHelper(name, function (context) {
     return async.resolve(fn.bind(this), context);
   });
 };
 
-// DEPRECATED, kept for backwards compatibility
-exports.SafeString = exports.handlebars.SafeString;
-exports.Utils = exports.handlebars.Utils;
+module.exports = new Instance();
+module.exports.create = function() {
+  return new Instance();
+};


### PR DESCRIPTION
- express-hbs is manage in a instance
- add a create method and expose through the module
- module.export create a new instance
- backward compatibility is maintained

Adds the possibility to create isolated instances with their own options, cache system and handlebars engine.
