### PR TITLE
Bug fixe in content/block helper

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -54,9 +54,9 @@ ExpressHbs.prototype.block = function(name) {
  * <link rel="stylesheet" href='{{{URL "css/style.css"}}}' />
  * {{/content}}
  */
-ExpressHbs.prototype.content = function(name, context) {
+ExpressHbs.prototype.content = function(name, options, context) {
   var block = this.blocks[name] || (this.blocks[name] = []);
-  block.push(context.fn(this));
+  block.push(options.fn(context));
 };
 
 /**
@@ -150,12 +150,13 @@ ExpressHbs.prototype.express3 = function(options) {
   this._options = options;
   if (this._options.handlebars) this.handlebars = this._options.handlebars;
 
-  // Keep the context call for the helpers and give the instance of express-hbs for access to blocks variables
   this.handlebars.registerHelper(this._options.blockHelperName, function(name) {
     return self.block(name);
   });
-  this.handlebars.registerHelper(this._options.contentHelperName, function(name, context) {
-    return self.content(name, context);
+
+  // Pass 'this' as context of helper function to don't lose context call of helpers.
+  this.handlebars.registerHelper(this._options.contentHelperName, function(name, options) {
+    return self.content(name, options, this);
   });
 
   // Absolute path to partials directory.


### PR DESCRIPTION
A part of my pull request https://github.com/barc/express-hbs/pull/32 was not merged, so there is a little bug in block/contentFor helper.

The data give to the template was lost in contentFor helpers, because the context of the function call in the helper was the ExpressHbs instance and not the context of the helper call.
