### PR TITLE
Missing new partials dir in the "app-layoutsDir" example app

### DIFF
--- a/example/app-layoutsDir.js
+++ b/example/app-layoutsDir.js
@@ -11,7 +11,7 @@ app.use(express.static(__dirname + '/public'));
 
 // Hook in express-hbs and tell it where known directories reside
 app.engine('hbs', hbs.express3({
-  partialsDir: __dirname + '/views/partials',
+  partialsDir: [__dirname + '/views/partials', __dirname + '/views/partials-other'],
   layoutsDir: __dirname + '/views/layout',
   defaultLayout: __dirname + '/views/layout/default.hbs'
 }));


### PR DESCRIPTION
The "app-layoutsDir" example is not working since the last commit 5c07499: _app-layoutsDir.js_ was not udpated with the new partials dir
