### PR TITLE
PJAX Support

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -415,13 +415,8 @@ function _express3(filename, options, cb) {
       }
 
       // Determine which layout to use
-      //   1. Layout specified in template
-      if (layoutTemplates) {
-        renderIt(layoutTemplates);
-      }
-
-      //   2. Layout specified by options from render
-      else if (typeof (options.layout) !== 'undefined') {
+      //   1. Layout specified by options from render
+      if (typeof (options.layout) !== 'undefined') {
         if (options.layout) {
           var layoutFile = self.layoutPath(filename, options.layout);
           self.cacheLayout(layoutFile, options.cache, function (err, layoutTemplates) {
@@ -433,6 +428,11 @@ function _express3(filename, options, cb) {
           // if the value is falsey, behave as if no layout should be used - suppress defaults
           renderIt(null);
         }
+      }
+
+      //   2. Layout specified in template
+      else if (layoutTemplates) {
+        renderIt(layoutTemplates);
       }
 
       //   3. Default layout specified when middleware was configured.


### PR DESCRIPTION
@mgutz, thanks for taking the time on the `0.7.0-pre` build, it was a good one.

Since I was working off a different fork, I had one additional change that provides PJAX support (specifically https://github.com/dakatsuka/express-pjax). I simply flipped the compile precedence order to take layout options first before template-specified layouts. Is there any reason template-specified layouts would need to be first? If not, this should be an easy one.
