### PR TITLE
Handle parser errors from handlebars

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -351,7 +351,13 @@ function _express3(filename, source, options, cb) {
    * @param cb
    */
   function renderTemplate(template, locals, cb) {
-    var res = template(locals, self._options.templateOptions);
+    var res;
+
+    try {
+      res = template(locals, self._options.templateOptions);
+    } catch (err) {
+        return cb(err, null);
+    }
 
     // Wait for async helpers
     async.done(function (values) {


### PR DESCRIPTION
fixes #47

This try-catch block at the very least ensures that parse errors are caught by express-hbs and passed into the express flow to be handled by any errorhandling middleware that is defined. However, the error message only contains the line-number, not the filename.

I looked at adding the filename to the error message, however because of the way express-hbs caches layouts and renders them in an abstracted way, this is going to be difficult to achieve.

Therefore, I'm submitting this, because it does at least fix error handling and is relatively straightforward.

I hope you don't mind that I opened #49 to track the need to add the filename.
