### PR TITLE
Changing error message to report filename not path

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -420,7 +420,7 @@ function _express3(filename, source, options, cb) {
       source = fs.readFileSync(filename, 'utf8');
       template = self.handlebars.compile(source);
       // for error message
-      template.__filename = filename;
+      template.__filename = filename.substring(filename.lastIndexOf(path.sep) + 1, filename.length);
       if (options.cache) {
         self.cache[filename] = { source: source, template: template };
       }

--- a/test/issues.js
+++ b/test/issues.js
@@ -179,7 +179,7 @@ describe('issue-49', function() {
     var render = hb.express3({});
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/error.hbs', locals, function(err, html) {
-      assert(err.stack.indexOf('/issues/49/error.hbs') > 0);
+      assert(err.stack.indexOf('error.hbs') > 0);
       done();
     });
   });


### PR DESCRIPTION
issue #49

This cleans up the reported filename to only include the name & extension, not the whole path.
