### PR TITLE
Escape the result of async handlers if {{...}} used.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -76,7 +76,7 @@ Waiter.resolve = function(fn, context) {
     waiter = new Waiter();
   }
 
-  var id = '__aSyNcId_' + gen_id() + '__';
+  var id = '__aSyNcId_<_' + gen_id() + '__';
 
   var cur_waiter = waiter;
   waiter.wait();

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -244,6 +244,7 @@ ExpressHbs.prototype.express3 = function(options) {
       if (self.asyncValues) {
         Object.keys(self.asyncValues).forEach(function (id) {
           val = val.replace(id, self.asyncValues[id]);
+          val = val.replace(self.Utils.escapeExpression(id), self.Utils.escapeExpression(self.asyncValues[id]));
         });
       }
     }
@@ -395,6 +396,7 @@ function _express3(filename, source, options, cb) {
 
       Object.keys(values).forEach(function (id) {
         res = res.replace(id, values[id]);
+        res = res.replace(self.Utils.escapeExpression(id), self.Utils.escapeExpression(values[id]));
       });
       cb(null, res);
     });

--- a/test/issues.js
+++ b/test/issues.js
@@ -239,7 +239,47 @@ describe('issue-53', function() {
   });
 });
 
+describe('issue-59', function() {
+    var dirname = __dirname + '/issues/59';
+    it('should escape or not', function (done) {
+        var hb = hbs.create();
 
+        function async(s, cb) {
+            cb('<strong>' + s + '</strong>');
+        }
+
+        hb.registerAsyncHelper("async", async);
+
+        var render = hb.express3({
+            viewsDir: dirname
+        });
+        var locals = H.createLocals('express3', dirname);
+
+        render(dirname + '/index.hbs', locals, function (err, html) {
+            assert.equal(H.stripWs(html), '&lt;strong&gt;foo&lt;/strong&gt;<strong>foo</strong>');
+            done();
+        });
+    });
+    it('should not escape SafeString', function (done) {
+        var hb = hbs.create();
+
+        function async(s, cb) {
+            cb(new hb.SafeString('<em>' + s + '</em>'));
+        }
+
+        hb.registerAsyncHelper("async", async);
+
+        var render = hb.express3({
+            viewsDir: dirname
+        });
+        var locals = H.createLocals('express3', dirname);
+
+        render(dirname + '/index.hbs', locals, function (err, html) {
+            assert.equal(H.stripWs(html), '<em>foo</em><em>foo</em>');
+            done();
+        });
+    });
+});
 
 
 

--- a/test/issues/59/index.hbs
+++ b/test/issues/59/index.hbs
@@ -1,0 +1,2 @@
+{{async "foo"}}
+{{{async "foo"}}}


### PR DESCRIPTION
Escape async handler results if {{...}} is used, but not escape if {{{...}}} is used.
Brings behaviour in line with other Handlebars behaviour.
Resolves issue #59
This is potentially breaking backwards compatibility if anyone was relying on {{...}} with async helpers not escaping.

This relies on the aSyNcId placeholder containing a character that will be escaped if {{...}} was used. This basically gives us two placeholders to replace, one that has a < in it (and thus must have been in a {{{...}}} since it was not escaped), and the other that has a &lt; in it (and thus must have been in a {{...}})

I can't see an obviously nicer way to fix this, sadly.
