### PR TITLE
Pass correct context to i18n helper

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -227,10 +227,14 @@ ExpressHbs.prototype.express3 = function(options) {
   if (options.i18n) {
     var i18n = options.i18n;
     this.handlebars.registerHelper('__', function() {
-      return i18n.__.apply(this, arguments);
+      var args = Array.prototype.slice.call(arguments);
+      var options = args.pop();
+      return i18n.__.apply(options.data.root, args);
     });
     this.handlebars.registerHelper('__n', function() {
-      return i18n.__n.apply(this, arguments);
+      var args = Array.prototype.slice.call(arguments);
+      var options = args.pop();
+      return i18n.__n.apply(options.data.root, args);
     });
   }
 

--- a/test/apps/i18n/index.js
+++ b/test/apps/i18n/index.js
@@ -42,7 +42,9 @@ function create(hbs, env) {
   app.use(i18n.init);
 
   app.get('/', function (req, res) {
-    res.render('index');
+    res.render('index', {
+      array: [1, 2]
+    });
   });
 
   return app;

--- a/test/apps/i18n/locales/en.json
+++ b/test/apps/i18n/locales/en.json
@@ -3,5 +3,6 @@
 	"%d cat": {
 		"one": "%d cat",
 		"other": "%d cats"
-	}
+	},
+	"each": "each"
 }

--- a/test/apps/i18n/locales/fr.json
+++ b/test/apps/i18n/locales/fr.json
@@ -3,5 +3,6 @@
     "%d cat": {
         "one": "%d chat",
         "other": "%d chats"
-    }
+    },
+    "each": "chaque"
 }

--- a/test/apps/i18n/views/index.hbs
+++ b/test/apps/i18n/views/index.hbs
@@ -1,5 +1,3 @@
 <span id="text">{{__ "text to test"}}</span>
 <br>
-<span id="onecat">{{__n "%d cat" "%d cats" 1}}</span>
-<br>
-<span id="twocats">{{__n "%d cat" "%d cats" 2}}</span>
+{{#each array}}<span class="{{__ "each"}}">{{__n "%d cat" "%d cats" .}}</span>{{/each}}

--- a/test/i18nSpecs.js
+++ b/test/i18nSpecs.js
@@ -15,7 +15,7 @@ describe('i18n', function() {
       .get('/')
       .set('Cookie', 'locale=en')
       .end(function(req, res) {
-        var expected = '<span id="text">text to test</span>\n<br>\n<span id="onecat">1 cat</span>\n<br>\n<span id="twocats">2 cats</span>\n';
+        var expected = '<span id="text">text to test</span>\n<br>\n<span class="each">1 cat</span><span class="each">2 cats</span>';
         assert.equal(res.text, expected);
         done();
       });
@@ -26,7 +26,7 @@ describe('i18n', function() {
       .get('/')
       .set('Cookie', 'locale=fr')
       .end(function(req, res) {
-        var expected = '<span id="text">Texte à tester</span>\n<br>\n<span id="onecat">1 chat</span>\n<br>\n<span id="twocats">2 chats</span>\n';
+        var expected = '<span id="text">Texte à tester</span>\n<br>\n<span class="chaque">1 chat</span><span class="chaque">2 chats</span>';
         assert.equal(res.text, expected);
         done();
       });


### PR DESCRIPTION
The i18n library requires the "this" keyword to point to the root
context, which has the current locale attached to it.  Inside of
an each block or other context where the "this" keyword points to
something else, translations will fail because it cannot find the
correct locale, unless we explicitly reference the root context.
