### PR TITLE
refactor: remove bluebird dep

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
     "node": true
   },
 
+  "parserOptions": {
+    "ecmaVersion": 2022,
+  },
+
   "globals": {
     "describe": true,
     "beforeEach": true,

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
-
 var generateId = require('./generate-id');
 
 var ID_LENGTH = 8;
@@ -28,12 +26,18 @@ function resolve(cache, fn, context) {
   return id;
 }
 
+// cache is an object where the keys are cache keys and values are promises. See above.
 function done(cache, callback) {
-  Promise.props(cache).then(function(values) {
-    callback(null, values);
-  }).catch(function(error) {
-    callback(error);
-  });
+  return Promise.all(Object.values(cache)).then((values) => {
+    const resolvedCache = {};
+    const keys = Object.keys(cache);
+    values.forEach((value, index) => {
+      resolvedCache[keys[index]] = value;
+    });
+    return callback(null, resolvedCache);
+  }).catch((error) => {
+    return callback(error);
+  })
 }
 
 function hasResolvers(text) {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "supertest": "6.3.3"
   },
   "dependencies": {
-    "bluebird": "^3.5.3",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "readdirp": "^3.6.0"
   },
   "optionalDependencies": {
     "js-beautify": "^1.13.11"
+  },
+  "engines": {
+    "node": ">=16"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,11 +477,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bluebird@^3.5.3:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"


### PR DESCRIPTION
Also, update eslintrc to support arrow notation.

Ref: https://github.com/TryGhost/Ghost/issues/14882

QA Log
======

I was concerned about the edge case where the cache was empty.

I checked that in that case, Object.keys({}) will return empty array,
and Promise.all([]); will return an array of length zero, so there's no
need to a further conditional case for this.

```
> Object.values({});
[]
> var foo = await Promise.all([])
undefined
> foo.length
0
```

To confirm the `done()` function I modified had test coverage, I manually introduced a bug in it and confirmed that tests failed. 
