### PR TITLE
Removed Bluebird dependency

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
-
 var generateId = require('./generate-id');
 
 var ID_LENGTH = 8;
@@ -28,9 +26,16 @@ function resolve(cache, fn, context) {
   return id;
 }
 
+// cache is an object where the keys are cache keys and values are promises. See above.
 function done(cache, callback) {
-  Promise.props(cache).then(function(values) {
-    callback(null, values);
+  return Promise.all(Object.values(cache))
+    .then(function(values) {
+      var resolvedCache = {};
+      var keys = Object.keys(cache);
+      values.forEach(function(value, index) {
+        resolvedCache[keys[index]] = value;
+      });
+      callback(null, resolvedCache);
   }).catch(function(error) {
     callback(error);
   });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "supertest": "6.3.3"
   },
   "dependencies": {
-    "bluebird": "^3.5.3",
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "readdirp": "^3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,11 +477,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bluebird@^3.5.3:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"


### PR DESCRIPTION
This is a re-done version of #252

Unlike the first take, this one does not use arrow functions
or `const` to comply with the current `eslint` rules of the project.

Also, the first draft used the `return callback` pattern which some eslint rulesets call for,
while this one continues to callback without an explicit return value.
