### PR TITLE
Added support for a restrictLayoutsTo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ hbs.express4({
   partialsDir: "{String/Array} [Required] Path to partials templates, one or several directories",
 
   // OPTIONAL settings
+  restrictLayoutsTo: "{String} Absolute path to a directory to restrict layout directive reading from",
   blockHelperName: "{String} Override 'block' helper name.",
   contentHelperName: "{String} Override 'contentFor' helper name.",
   defaultLayout: "{String} Absolute path to default layout template",
@@ -99,9 +100,9 @@ There are three ways to use a layout, listed in precedence order
 
 2.  As an option to render
 
-    ## ⚠️ This creates a potential security vulnerability:
+    ## ⚠️ This creates a potential security vulnerability if used without a `restrictLayoutsTo`:
 
-    Do not use this option in conjunction with passing user submitted data to res.render e.g. `res.render('index', req.query)`. This allows users to read arbitrary files from your filesystem!
+    The `restrictLayoutsTo` option will restrict reading layouts to a particular directory, if you do not pass this option then do not use the `layout` option in conjunction with passing user submitted data to res.render e.g. `res.render('index', req.query)`. This allows users to read arbitrary files from your filesystem!
 
     ```js
     res.render('veggies', {

--- a/example/app-layoutsDir.js
+++ b/example/app-layoutsDir.js
@@ -19,7 +19,8 @@ app.use(express.static(relative('public')));
 app.engine('hbs', hbs.express4({
   partialsDir: [relative('views/partials'), relative('views/partials-other')],
   layoutsDir: relative('views/layout'),
-  defaultLayout: relative('views/layout/default.hbs')
+  defaultLayout: relative('views/layout/default.hbs'),
+  restrictLayoutsTo: relative('views/layout')
 }));
 app.set('view engine', 'hbs');
 app.set('views', relative('views'));

--- a/example/app.js
+++ b/example/app.js
@@ -20,7 +20,8 @@ function create(hbs, env) {
   // Hook in express-hbs and tell it where known directories reside
   app.engine('hbs', hbs.express4({
     partialsDir: [relative('views/partials'), relative('views/partials-other')],
-    defaultLayout: relative('views/layout/default.hbs')
+    defaultLayout: relative('views/layout/default.hbs'),
+    restrictLayoutsTo: viewsDir
   }));
   app.set('view engine', 'hbs');
   app.set('views', viewsDir);

--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -99,6 +99,13 @@ ExpressHbs.prototype.declaredLayoutFile = function(str, filename) {
 ExpressHbs.prototype.cacheLayout = function(layoutFile, useCache, cb) {
   var self = this;
 
+  if (this.restrictLayoutsTo) {
+    if (!layoutFile.startsWith(this.restrictLayoutsTo)) {
+      var err = new Error('Cannot read ' + layoutFile + ' it does not reside in ' + this.restrictLayoutsTo);
+      return cb(err, null);
+    }
+  }
+
   // assume hbs extension
   if (path.extname(layoutFile) === '') layoutFile += this._options.extname;
 
@@ -253,6 +260,8 @@ ExpressHbs.prototype.express3 = function(options) {
 
   // Absolute path to the layouts directory
   this.layoutsDir = this._options.layoutsDir;
+
+  this.restrictLayoutsTo = this._options.restrictLayoutsTo;
 
   // express passes this through ___express func, gulp pass in an option
   this.viewsDir = null;

--- a/test/apps/async/index.js
+++ b/test/apps/async/index.js
@@ -65,7 +65,8 @@ function create(hbs, env) {
 
   // Hook in express-hbs and tell it where known directories reside
   app.engine('hbs', hbs.express4({
-    defaultLayout: path.join(viewsDir, "layout.hbs")
+    defaultLayout: path.join(viewsDir, 'layout.hbs'),
+    restrictLayoutsTo: viewsDir
   }));
   app.set('view engine', 'hbs');
   app.set('views', viewsDir);

--- a/test/apps/i18n/index.js
+++ b/test/apps/i18n/index.js
@@ -31,7 +31,8 @@ function create(hbs, env) {
 
   // Hook in express-hbs and tell it where known directories reside
   app.engine('hbs', hbs.express3({
-    i18n: i18n
+    i18n: i18n,
+    restrictLayoutsTo: viewsDir
   }));
   app.set('view engine', 'hbs');
   app.set('views', viewsDir);

--- a/test/customExtension.js
+++ b/test/customExtension.js
@@ -11,7 +11,8 @@ describe('custom extension for partials view', function() {
   var dirname = path.join(__dirname, 'views/customExtension');
   var render = hbs.create().express4({
       extname: '.server.view.html',
-      partialsDir: dirname + '/partialsDir'
+      partialsDir: dirname + '/partialsDir',
+      restrictLayoutsTo: dirname
   });
 
   it('should allow rendering multiple partials with custom extension', function(done) {

--- a/test/helperSpecs.js
+++ b/test/helperSpecs.js
@@ -15,7 +15,8 @@ describe('helpers', function() {
       var hb = hbs.create();
       hb.registerHelper("sync", sync);
       var render = hb.express3({
-        viewsDir: dirname
+        viewsDir: dirname,
+        restrictLayoutsTo: dirname
       });
       var locals = H.createLocals('express3', dirname);
 
@@ -38,7 +39,8 @@ describe('helpers', function() {
       hb.registerAsyncHelper("async", async);
 
       var render = hb.express3({
-        viewsDir: dirname
+        viewsDir: dirname,
+        restrictLayoutsTo: dirname
       });
       var locals = H.createLocals('express3', dirname);
 

--- a/test/issues.js
+++ b/test/issues.js
@@ -9,7 +9,9 @@ describe('issue-22 template', function() {
   var dirname = path.join(__dirname, 'issues/22');
 
   it('should use multiple layouts with caching', function(done) {
-    var render = hbs.create().express3({});
+    var render = hbs.create().express3({
+      restrictLayoutsTo: dirname
+    });
     var locals1 = H.createLocals('express3', dirname, { layout: 'layout1', cache: true });
     var locals2 = H.createLocals('express3', dirname, { layout: 'layout2', cache: true });
 
@@ -30,7 +32,8 @@ describe('issue-23', function() {
 
   it('should not pass an empty or missing partial to handlebars', function(done) {
     var render = hbs.create().express3({
-      partialsDir: [dirname + '/partials']
+      partialsDir: [dirname + '/partials'],
+      restrictLayoutsTo: dirname
     });
 
     function check(err, html) {
@@ -43,7 +46,8 @@ describe('issue-23', function() {
 
   it('should handle empty string', function(done) {
     var render = hbs.create().express3({
-      partialsDir: [dirname + '/partials']
+      partialsDir: [dirname + '/partials'],
+      restrictLayoutsTo: dirname
     });
 
     function check(err, html) {
@@ -58,7 +62,8 @@ describe('issue-23', function() {
   it('should register empty partial', function(done) {
     var hb = hbs.create();
     var render = hb.express3({
-      partialsDir: [dirname + '/partials']
+      partialsDir: [dirname + '/partials'],
+      restrictLayoutsTo: dirname
     });
     hb.handlebars.registerPartial('emptyPartial', '');
 
@@ -82,7 +87,8 @@ describe('issue-23', function() {
   it('should register partial that results in empty string (comment)', function(done) {
     var hb = hbs.create();
     var render = hb.express3({
-      partialsDir: [dirname + '/partials']
+      partialsDir: [dirname + '/partials'],
+      restrictLayoutsTo: dirname
     });
     // this fails
     //hb.handlebars.registerPartial('emptyComment', '{{! just a comment}}');
@@ -110,7 +116,8 @@ describe('issue-23', function() {
 describe('issue-21', function() {
   var dirname =  path.join(__dirname, 'issues/21');
   var render = hbs.create().express3({
-    layoutsDir: dirname + '/views/layouts'
+    layoutsDir: dirname + '/views/layouts',
+    restrictLayoutsTo: dirname
   });
 
   it('should allow specifying layouts without the parent dir', function(done) {
@@ -158,7 +165,9 @@ describe('issue-21', function() {
 
   it('should treat layouts relative to views directory if layoutsDir is not passed', function(done) {
     var dirname =  path.join(__dirname, 'issues/21');
-    var render = hbs.create().express3();
+    var render = hbs.create().express3({
+      restrictLayoutsTo: dirname
+    });
 
     function check(err, html) {
       assert.ifError(err);
@@ -177,7 +186,9 @@ describe('issue-49', function() {
 
   it('should report filename with error', function(done) {
     var hb = hbs.create()
-    var render = hb.express3({});
+    var render = hb.express3({
+      restrictLayoutsTo: dirname
+    });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/error.hbs', locals, function(err, html) {
       assert(err.stack.indexOf('[error.hbs]') > 0);
@@ -187,7 +198,9 @@ describe('issue-49', function() {
 
   it('should report relative filename with error', function(done) {
     var hb = hbs.create()
-    var render = hb.express3({});
+    var render = hb.express3({
+      restrictLayoutsTo: dirname
+    });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/front/error.hbs', locals, function(err, html) {
       assert(err.stack.indexOf('[front/error.hbs]') > 0);
@@ -198,7 +211,8 @@ describe('issue-49', function() {
   it('should report filename with partial error', function(done) {
     var hb = hbs.create()
     var render = hb.express3({
-      partialsDir: dirname + '/partials'
+      partialsDir: dirname + '/partials',
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/partial.hbs', locals, function(err, html) {
@@ -210,7 +224,8 @@ describe('issue-49', function() {
   it('should report filename with layout error', function(done) {
     var hb = hbs.create()
     var render = hb.express3({
-      partialsDir: dirname + '/partials'
+      partialsDir: dirname + '/partials',
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/index.hbs', locals, function(err, html) {
@@ -231,7 +246,9 @@ describe('issue-53', function() {
         resultcb(++res);
       }, 1)
     });
-    var render = hb.express3({});
+    var render = hb.express3({
+      restrictLayoutsTo: dirname
+    });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/index.hbs', locals, function(err, html) {
       assert.ifError(err);
@@ -253,7 +270,8 @@ describe('issue-59', function() {
     hb.registerAsyncHelper("async", async);
 
     var render = hb.express3({
-      viewsDir: dirname
+      viewsDir: dirname,
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname);
 
@@ -272,7 +290,8 @@ describe('issue-59', function() {
     hb.registerAsyncHelper('async', async);
 
     var render = hb.express3({
-      viewsDir: dirname
+      viewsDir: dirname,
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname);
 
@@ -290,6 +309,7 @@ describe('issue-73', function() {
     var render = hb.express3({
       viewsDir: dirname,
       partialsDir: dirname + '/partials',
+      restrictLayoutsTo: dirname,
       onCompile: function(eh, source, filename) {
         var options;
         if (filename && filename.indexOf('partials')) {
@@ -329,7 +349,8 @@ describe('issue-62', function() {
     hb.registerAsyncHelper("async", async);
 
     var render = hb.express3({
-      viewsDir: dirname
+      viewsDir: dirname,
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname);
 
@@ -359,7 +380,8 @@ describe('issue-62', function() {
     hb.registerAsyncHelper("async", async);
 
     var render = hb.express3({
-      viewsDir: dirname
+      viewsDir: dirname,
+      restrictLayoutsTo: dirname
     });
     var locals = H.createLocals('express3', dirname);
 
@@ -380,7 +402,8 @@ describe('issue-76', function() {
     var hb = hbs.create();
 
     var render = hb.express3({
-      partialsDir: dirname
+      partialsDir: dirname,
+      restrictLayoutsTo: dirname
     });
 
     hb.cachePartials(function (err) {
@@ -396,7 +419,8 @@ describe('issue-84', function () {
 
   it('should render deeply nested partials', function (done) {
     var render = hbs.create().express3({
-      partialsDir: [dirname + '/partials']
+      partialsDir: [dirname + '/partials'],
+      restrictLayoutsTo: dirname
     });
 
     function check(err, html) {
@@ -421,7 +445,9 @@ describe('issue-144', function() {
         resultcb(new hbs.SafeString('<p><code>\'$example$\'</code> abcd</p>'));
       }, 1)
     });
-    var render = hb.express3({});
+    var render = hb.express3({
+      restrictLayoutsTo: dirname
+    });
     var locals = H.createLocals('express3', dirname, {});
     render(dirname + '/index.hbs', locals, function(err, html) {
       assert.equal('<div><p><code>\'$example$\'</code> abcd</p></div>\n', html);
@@ -441,7 +467,9 @@ describe('issue-153', function() {
       done();
     }
     var hb = hbs.create()
-    var render = hb.express3({});
+    var render = hb.express3({
+      restrictLayoutsTo: dirname
+    });
     var locals = H.createLocals('express3', dirname, { });
     render(dirname + '/index.hbs', locals, check);
   });

--- a/test/layoutSpecs.js
+++ b/test/layoutSpecs.js
@@ -1,5 +1,6 @@
 var request = require('supertest');
 var assert = require('assert');
+var path = require('path');
 var hbs = require('..');
 
 
@@ -65,6 +66,7 @@ describe('layouts', function() {
 
     it ('should process template-specified layout without option', function(done) {
       var render = hbs.create().express3({
+        restrictLayoutsTo: dirname
       });
       var locals = createLocals('express3', dirname);
 
@@ -76,6 +78,7 @@ describe('layouts', function() {
 
     it ('should allow options.layout to be specified', function(done) {
       var render = hbs.create().express3({
+        restrictLayoutsTo: dirname
       });
       var locals = createLocals('express3', dirname, { layout: 'layouts/default' });
 
@@ -85,8 +88,23 @@ describe('layouts', function() {
       });
     });
 
+    it('should error when using a layout outside of the restrictLayoutsTo', function(done) {
+      var render = hbs.create().express3({
+        restrictLayoutsTo: path.resolve(path.join(__dirname, '../'))
+      });
+      var locals = createLocals('express3', dirname, {layout: '/Users/egg/Code/Ghost/ghost/core/package.json'});
+
+      render(dirname + '/aside.hbs', locals, function (err, html) {
+        if (!err) {
+          return done(new Error('We expect an error when reading'));
+        }
+        return done();
+      });
+    });
+
     it ('should not process template-specified layout when options.layout is falsy', function(done) {
       var render = hbs.create().express3({
+        restrictLayoutsTo: dirname
       });
       var locals = createLocals('express3', dirname, { layout: false });
 

--- a/test/localTemplateOptions.js
+++ b/test/localTemplateOptions.js
@@ -11,7 +11,9 @@ describe('local template options', function () {
 
     it('merges res.locals._templateOptions with the self._templateOptions', function (done) {
       var instance = hbs.create();
-      var render = instance.express3({});
+      var render = instance.express3({
+        restrictLayoutsTo: dirname
+      });
       instance.updateTemplateOptions({
           data: {
             greeting: 'Hello,',
@@ -37,7 +39,9 @@ describe('local template options', function () {
 
     it('removes _templateOptions from the locals data', function (done) {
       var instance = hbs.create();
-      var render = instance.express3({});
+      var render = instance.express3({
+        restrictLayoutsTo: dirname
+      });
       instance.updateTemplateOptions({
           data: {
             greeting: 'Hello,',
@@ -66,7 +70,9 @@ describe('local template options', function () {
 
     it('merges res.locals._templateOptions with the self._templateOptions', function (done) {
       var instance = hbs.create();
-      var render = instance.express4({});
+      var render = instance.express4({
+        restrictLayoutsTo: dirname
+      });
       instance.updateTemplateOptions({
           data: {
             greeting: 'Hello,',
@@ -92,7 +98,9 @@ describe('local template options', function () {
 
     it('removes _templateOptions from the locals data', function (done) {
       var instance = hbs.create();
-      var render = instance.express3({});
+      var render = instance.express3({
+        restrictLayoutsTo: dirname
+      });
       instance.updateTemplateOptions({
           data: {
             greeting: 'Hello,',

--- a/test/multiple.js
+++ b/test/multiple.js
@@ -10,7 +10,9 @@ describe('multiple directories', function() {
 
   beforeEach(function() {
     app = express();
-    app.engine('hbs', hbs.express3());
+    app.engine('hbs', hbs.express3({
+      restrictLayoutsTo: './test/views/multiple'
+    }));
     app.set('view engine', 'hbs');
     app.get('/test1', function (req, res) {
       res.render('test1');

--- a/test/nonExpress.js
+++ b/test/nonExpress.js
@@ -9,7 +9,8 @@ describe('non-express', function() {
 
     it ('should use viewsDir options', function(done) {
       var render = hbs.create().express3({
-        viewsDir: dirname
+        viewsDir: dirname,
+        restrictLayoutsTo: dirname
       });
       var locals = H.createLocals('express3', dirname);
 
@@ -22,7 +23,8 @@ describe('non-express', function() {
     it ('should work with layoutsDir', function(done) {
       var render = hbs.create().express3({
         viewsDir: dirname,
-        layoutsDir: dirname + '/layouts'
+        layoutsDir: dirname + '/layouts',
+        restrictLayoutsTo: dirname
       });
       var locals = H.createLocals('express3', dirname, {layout: 'default.hbs'});
 

--- a/test/optionsSpecs.js
+++ b/test/optionsSpecs.js
@@ -10,7 +10,7 @@ describe('options', function() {
 
   it('should pretty print HTML', function(done) {
     var hb = hbs.create();
-    var render = hb.express3({beautify: true});
+    var render = hb.express3({beautify: true, restrictLayoutsTo: dirname});
     var locals = H.createLocals('express3', dirname, {});
 
     render(dirname + '/index.hbs', locals, function(err, html) {


### PR DESCRIPTION
Passing this option will cause express-hbs to error when attempting to read a layout from outside of the path. This is used to help alleviate the security concerns when using user submitted data for choosing layouts

Long term, in a major release we can use the `layoutsDir` option for this, but we did not want to make a breaking change at this stage.