### PR TITLE
add support for providing a hash for parameter insertion into strings

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -230,11 +230,17 @@ ExpressHbs.prototype.express3 = function(options) {
     this.handlebars.registerHelper('__', function() {
       var args = Array.prototype.slice.call(arguments);
       var options = args.pop();
+      if (Object.keys(options.hash).length > 0) {
+        args.push(options.hash);
+      }
       return i18n.__.apply(options.data.root, args);
     });
     this.handlebars.registerHelper('__n', function() {
       var args = Array.prototype.slice.call(arguments);
       var options = args.pop();
+      if (Object.keys(options.hash).length > 0) {
+        args.push(options.hash);
+      }
       return i18n.__n.apply(options.data.root, args);
     });
   }


### PR DESCRIPTION
example: `{{__ "my-key" p1="foo" p2="bar"}}`

I couldn't find any tests for i18n functionality.