### PR TITLE
Fix restrictLayoutsTo containment checks for absolute paths

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -100,7 +100,14 @@ ExpressHbs.prototype.cacheLayout = function(layoutFile, useCache, cb) {
   var self = this;
 
   if (this.restrictLayoutsTo) {
-    if (!layoutFile.startsWith(this.restrictLayoutsTo)) {
+    var restrictLayoutsTo = path.resolve(this.restrictLayoutsTo);
+    var resolvedLayoutFile = path.resolve(layoutFile);
+    var relativeLayoutPath = path.relative(restrictLayoutsTo, resolvedLayoutFile);
+    var isOutsideRestrictedDir = relativeLayoutPath === '..' ||
+      relativeLayoutPath.startsWith('..' + path.sep) ||
+      path.isAbsolute(relativeLayoutPath);
+
+    if (isOutsideRestrictedDir) {
       var err = new Error('Cannot read ' + layoutFile + ' it does not reside in ' + this.restrictLayoutsTo);
       return cb(err, null);
     }

--- a/test/layoutSpecs.js
+++ b/test/layoutSpecs.js
@@ -88,6 +88,20 @@ describe('layouts', function() {
       });
     });
 
+    it ('should allow absolute layout path when restrictLayoutsTo is relative', function(done) {
+      var render = hbs.create().express3({
+        restrictLayoutsTo: path.relative(process.cwd(), dirname)
+      });
+      var locals = createLocals('express3', dirname, {
+        layout: path.resolve(path.join(dirname, 'layouts/default'))
+      });
+
+      render(dirname + '/aside.hbs', locals, function(err, html) {
+        assert.equal('<dld>aside</dld>', stripWs(html));
+        done();
+      });
+    });
+
     it('should error when using a layout outside of the restrictLayoutsTo', function(done) {
       var render = hbs.create().express3({
         restrictLayoutsTo: path.resolve(path.join(__dirname, '../'))
@@ -95,6 +109,22 @@ describe('layouts', function() {
       var locals = createLocals('express3', dirname, {layout: '/Users/egg/Code/Ghost/ghost/core/package.json'});
 
       render(dirname + '/aside.hbs', locals, function (err, html) {
+        if (!err) {
+          return done(new Error('We expect an error when reading'));
+        }
+        return done();
+      });
+    });
+
+    it('should error when layout path only matches restrictLayoutsTo as a prefix', function(done) {
+      var render = hbs.create().express3({
+        restrictLayoutsTo: dirname
+      });
+      var locals = createLocals('express3', dirname, {
+        layout: path.resolve(path.join(__dirname, 'views/disableLayoutDirectiveEvil/layouts/default'))
+      });
+
+      render(dirname + '/aside.hbs', locals, function(err, html) {
         if (!err) {
           return done(new Error('We expect an error when reading'));
         }

--- a/test/views/disableLayoutDirectiveEvil/layouts/default.hbs
+++ b/test/views/disableLayoutDirectiveEvil/layouts/default.hbs
@@ -1,0 +1,1 @@
+<evil>{{{body}}}</evil>


### PR DESCRIPTION
## What this fixes
- Replaces the `startsWith` path check in `cacheLayout` with a `path.relative` containment check.
- Correctly handles cases where `restrictLayoutsTo` is relative and the layout path is absolute.
- Blocks sibling-prefix bypasses (e.g. `/allowed` vs `/allowed-evil`).

## Tests added
- Allows absolute layout paths when `restrictLayoutsTo` is relative.
- Rejects layouts that only match `restrictLayoutsTo` by string prefix.

Fixes #270
