### PR TITLE
Add stable required CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,13 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn coverage
+
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: needs.build.result != 'success'
+        run: exit 1


### PR DESCRIPTION
## Summary

- add a stable `All tests pass` aggregator job
- make it depend on the complete Node 20/22/24 build matrix
- fail the stable check whenever the required matrix job does not succeed

Repository rules can require this single context without coupling branch protection to individual matrix job names.

## Verification

- default-branch CI after #285: [Test #2226](https://github.com/TryGhost/express-hbs/actions/runs/28523376399) succeeded in 27 seconds across all three matrix jobs
- workflow YAML parse
- `git diff --check`

ref [GVA-828](https://linear.app/ghost/issue/GVA-828/clean-repos-express-hbs)