### PR TITLE
Use shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "@tryghost:quietJS",
-    "@tryghost:automergeDevDependencies"
+    "local>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Summary

Standardize this repository's Renovate configuration with the shared TryGhost preset:

```json
"local>TryGhost/renovate-config"
```

## Preset decision

- Expected preset: `default`
- CI-trust source: live verification and repo-meta both report high trust
- Live evidence: enforced 80% statements/branches/functions/lines coverage, real Express/package acceptance coverage, Node 20/22/24 validation, and the stable required `All tests pass` check
- Breaking-update proof: Renovate’s Express 5 PR #267 passed the protected workflow and default-branch CI after merge

## Configuration changes

- Previous location: `renovate.json`
- New location: `renovate.json`
- Added the Renovate schema reference
- Replaced `@tryghost:quietJS` with the canonical shared preset; the default preset already extends Ghost’s quiet configuration
- Dropped `@tryghost:automergeDevDependencies` because the shared quiet configuration already defines the organization’s dependency automerge policy
- No `package.json` Renovate key existed or was removed
- No local package rules were retained or added
- Runtime compatibility rule: not applicable; CI deliberately uses a floating Node 20/22/24 matrix rather than an exact production or consumer patch pin
- Package-manager cap: not applicable in this Yarn-based slice; pnpm compatibility is handled by the later package-manager migration gate

## Verification

- `renovate-config-validator renovate.json` — config validated successfully
- JSON parse
- `git diff --check`

ref [GVA-828](https://linear.app/ghost/issue/GVA-828/clean-repos-express-hbs)