### PR TITLE
Add CI job timeout and concurrency guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,18 @@ on:
   push:
     branches:
       - main
-      - 'renovate/*'
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +41,7 @@ jobs:
     if: always()
     needs: [build]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Verify all required jobs succeeded
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
## Why

On 2026-07-06, Renovate PR #278 (`readdirp` v5, ESM-only) repeatedly rebased `renovate/readdirp-5.x`. The test process **hung** on `pnpm coverage` instead of failing (readdirp v5 is the scanner under chokidar's watcher; the watcher never tears down, so Node never exits). With no job timeout, each hung job squatted its `ubuntu-latest` runner toward the 6h default; with no concurrency guard, each rebase stacked more hung jobs. ~11 stacked runs × 3 Node versions ≈ 33 hosted-runner slots pinned for ~5h. Because GitHub-hosted runners share one **org-wide** concurrency pool, CI queued across the whole TryGhost org (Ghost, Daisy.js, Migrate-App, billing, …).

## Changes

- **`timeout-minutes: 20`** on the build matrix (and `5` on the gate job) — a hang now dies in minutes, not 6 hours. Normal runs here complete in well under 20 min.
- **`concurrency` with `cancel-in-progress: true`**, keyed to PR number / ref — repeated rebases supersede the previous run instead of stacking.
- **Dropped `push: branches: ['renovate/*']`** — this workflow fired on *both* `push` and `pull_request` for renovate branches, doubling every run. Renovate PRs are still fully tested via the `pull_request` event; they now run once.

Any single one of these would have contained the incident; together they prevent recurrence.