### PR TITLE
Apply the fail-closed pnpm 10 baseline

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+strictDepBuilds: true
+minimumReleaseAge: 4320
+blockExoticSubdeps: true


### PR DESCRIPTION
## What changed

Added `pnpm-workspace.yaml` with the shared pnpm 10 supply-chain baseline:

- `minimumReleaseAge: 4320` enforces a 72-hour cooldown for newly published dependencies.
- `strictDepBuilds: true` makes installation fail when an unapproved dependency requests a lifecycle build script.
- `blockExoticSubdeps: true` rejects exotic Git and tarball sources in transitive dependencies.

`express-hbs` had no existing build approvals, and its current lockfile contains no dependencies requiring lifecycle builds, so this PR adds no `allowBuilds` permissions or denials.

## Why

`express-hbs` publishes runtime code consumed by Ghost. pnpm 10 otherwise defaults to no release cooldown and only warns when unapproved builds are skipped. These settings align the repository with the fail-closed dependency-install policy without expanding the package execution surface.

This is the `express-hbs` portion of [PLA-320](https://linear.app/ghost/issue/PLA-320/apply-the-fail-closed-pnpm-10-baseline-to-ghost-package-repositories).

## Impact

There is no runtime or package behavior change. Future dependencies wait 72 hours before becoming eligible, exotic transitive sources are rejected, and any dependency that introduces a required lifecycle script will need an intentional, version-scoped approval and security review.

The existing `packageManager` pin remains `pnpm@10.34.5`.

## Validation

- `corepack pnpm --version` (`10.34.5`)
- Effective pnpm config verified with `pnpm config get` for all three settings
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm test` (73 passing, including lint and formatting)
- `corepack pnpm coverage` (73 passing; coverage thresholds met)
- `corepack pnpm publish --no-git-checks --dry-run`
- `git diff --check`

This repository is a source-only package and has no build script or generated build artifact.